### PR TITLE
feat: set global input state, synchronize methods

### DIFF
--- a/GodotTestDriver.Tests/ActionsControlExtensionsTest.cs
+++ b/GodotTestDriver.Tests/ActionsControlExtensionsTest.cs
@@ -1,0 +1,37 @@
+namespace GodotTestDriver.Tests;
+
+using System;
+using System.Threading.Tasks;
+using Chickensoft.GoDotTest;
+using Godot;
+using GodotTestDriver.Input;
+using GodotTestDriver.Util;
+using JetBrains.Annotations;
+using Shouldly;
+
+[UsedImplicitly]
+public class ActionsControlExtensionsTest : DriverTest
+{
+    private const string TestAction = "test_action";
+
+    public ActionsControlExtensionsTest(Node testScene) : base(testScene)
+    {
+    }
+
+    [Test]
+    public async Task StartActionSetsGlobalActionPressed()
+    {
+        Input.IsActionPressed(TestAction).ShouldBeFalse();
+        await RootNode.StartAction(TestAction);
+        Input.IsActionPressed(TestAction).ShouldBeTrue();
+        await RootNode.EndAction(TestAction);
+    }
+
+    [Test]
+    public async Task EndActionUnsetsGlobalActionPressed()
+    {
+        await RootNode.StartAction(TestAction);
+        await RootNode.EndAction(TestAction);
+        Input.IsActionPressed(TestAction).ShouldBeFalse();
+    }
+}

--- a/GodotTestDriver.Tests/ActionsControlExtensionsTest.cs
+++ b/GodotTestDriver.Tests/ActionsControlExtensionsTest.cs
@@ -34,4 +34,20 @@ public class ActionsControlExtensionsTest : DriverTest
         await RootNode.EndAction(TestAction);
         Input.IsActionPressed(TestAction).ShouldBeFalse();
     }
+
+    [Test]
+    public async Task StartActionSetsGlobalActionJustPressed()
+    {
+        await RootNode.StartAction(TestAction);
+        Input.IsActionJustPressed(TestAction).ShouldBeTrue();
+        await RootNode.EndAction(TestAction);
+    }
+
+    [Test]
+    public async Task EndActionSetsGlobalActionJustReleased()
+    {
+        await RootNode.StartAction(TestAction);
+        await RootNode.EndAction(TestAction);
+        Input.IsActionJustReleased(TestAction).ShouldBeTrue();
+    }
 }

--- a/GodotTestDriver.Tests/ActionsControlExtensionsTest.cs
+++ b/GodotTestDriver.Tests/ActionsControlExtensionsTest.cs
@@ -1,11 +1,7 @@
 namespace GodotTestDriver.Tests;
-
-using System;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Input;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 using Shouldly;
 
@@ -19,35 +15,35 @@ public class ActionsControlExtensionsTest : DriverTest
     }
 
     [Test]
-    public async Task StartActionSetsGlobalActionPressed()
+    public void StartActionSetsGlobalActionPressed()
     {
         Input.IsActionPressed(TestAction).ShouldBeFalse();
-        await RootNode.StartAction(TestAction);
+        RootNode.StartAction(TestAction);
         Input.IsActionPressed(TestAction).ShouldBeTrue();
-        await RootNode.EndAction(TestAction);
+        RootNode.EndAction(TestAction);
     }
 
     [Test]
-    public async Task EndActionUnsetsGlobalActionPressed()
+    public void EndActionUnsetsGlobalActionPressed()
     {
-        await RootNode.StartAction(TestAction);
-        await RootNode.EndAction(TestAction);
+        RootNode.StartAction(TestAction);
+        RootNode.EndAction(TestAction);
         Input.IsActionPressed(TestAction).ShouldBeFalse();
     }
 
     [Test]
-    public async Task StartActionSetsGlobalActionJustPressed()
+    public void StartActionSetsGlobalActionJustPressed()
     {
-        await RootNode.StartAction(TestAction);
+        RootNode.StartAction(TestAction);
         Input.IsActionJustPressed(TestAction).ShouldBeTrue();
-        await RootNode.EndAction(TestAction);
+        RootNode.EndAction(TestAction);
     }
 
     [Test]
-    public async Task EndActionSetsGlobalActionJustReleased()
+    public void EndActionSetsGlobalActionJustReleased()
     {
-        await RootNode.StartAction(TestAction);
-        await RootNode.EndAction(TestAction);
+        RootNode.StartAction(TestAction);
+        RootNode.EndAction(TestAction);
         Input.IsActionJustReleased(TestAction).ShouldBeTrue();
     }
 }

--- a/GodotTestDriver.Tests/ActionsControlExtensionsTest.tscn
+++ b/GodotTestDriver.Tests/ActionsControlExtensionsTest.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://busk27caw7oi8"]
+
+[node name="ActionsControlExtensionsTest" type="Node"]

--- a/GodotTestDriver.Tests/ButtonDriverTest.cs
+++ b/GodotTestDriver.Tests/ButtonDriverTest.cs
@@ -1,7 +1,6 @@
 namespace GodotTestDriver.Tests;
 
 using System;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -23,11 +22,11 @@ public class ButtonDriverTest : DriverTest
     }
 
     [Test]
-    public async Task ClickingWorks()
+    public void ClickingWorks()
     {
         // WHEN
         // i click the button
-        await _button.ClickCenter();
+        _button.ClickCenter();
         // the label text changes.
         _label.Text.ShouldBe("did work");
         // and the panel disappears
@@ -35,22 +34,22 @@ public class ButtonDriverTest : DriverTest
     }
 
     [Test]
-    public async Task ClickingDisabledButtonThrowsException()
+    public void ClickingDisabledButtonThrowsException()
     {
         // SETUP
         _button.PresentRoot.Disabled = true;
         // WHEN
         // i click the button then an exception is thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _button.ClickCenter());
+        Should.Throw<InvalidOperationException>(() => _button.ClickCenter());
     }
 
     [Test]
-    public async Task ClickingHiddenButtonThrowsException()
+    public void ClickingHiddenButtonThrowsException()
     {
         // SETUP
         _button.PresentRoot.Visible = false;
         // WHEN
         // i click the button then an exception is thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _button.ClickCenter());
+        Should.Throw<InvalidOperationException>(() => _button.ClickCenter());
     }
 }

--- a/GodotTestDriver.Tests/Camera2DDriverTest.cs
+++ b/GodotTestDriver.Tests/Camera2DDriverTest.cs
@@ -1,4 +1,3 @@
-﻿
 namespace GodotTestDriver.Tests;
 
 using System.Threading.Tasks;
@@ -37,10 +36,13 @@ public class Camera2DDriverTest : DriverTest
     {
         // WHEN
         // I move camera to off-center sprite
-        await _camera2D.MoveIntoView(_offCenterSprite.GlobalPosition, 2);
+        var moveTask = _camera2D.MoveIntoView(_offCenterSprite.GlobalPosition, 2);
 
         // THEN
-        //  the off center sprite is not visible
+        //  the camera has successfully moved to the new position
+        (await moveTask).ShouldBeTrue();
+
+        //  and off center sprite is visible
         _offCenterSprite.IsFullyInView.ShouldBeTrue();
     }
 }

--- a/GodotTestDriver.Tests/CheckBoxDriverTest.cs
+++ b/GodotTestDriver.Tests/CheckBoxDriverTest.cs
@@ -1,6 +1,5 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -18,11 +17,11 @@ public class CheckBoxDriverTest : DriverTest
     }
 
     [Test]
-    public async Task ClickingChecksAndUnchecks()
+    public void ClickingChecksAndUnchecks()
     {
         // WHEN
         // i click the checkbox
-        await _checkBox.ClickCenter();
+        _checkBox.ClickCenter();
 
         // THEN
         // the checkbox is checked
@@ -30,7 +29,7 @@ public class CheckBoxDriverTest : DriverTest
 
         // WHEN
         // i click the checkbox again
-        await _checkBox.ClickCenter();
+        _checkBox.ClickCenter();
 
         // THEN
         // the checkbox is unchecked

--- a/GodotTestDriver.Tests/GraphEditDriverTest.cs
+++ b/GodotTestDriver.Tests/GraphEditDriverTest.cs
@@ -1,7 +1,6 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
 using System.Linq;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -51,7 +50,7 @@ public class GraphEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task DraggingNodesWorks()
+    public void DraggingNodesWorks()
     {
         // SETUP
         var firstNode = _graphEdit.Nodes.First();
@@ -59,7 +58,7 @@ public class GraphEditDriverTest : DriverTest
         var firstNodeOffset = firstNode.Offset;
         // WHEN
         // i drag the first node
-        await firstNode.DragByOwnSize(2, 0);
+        firstNode.DragByOwnSize(2, 0);
 
         // THEN
         // the offset has changed by 2x it's width
@@ -71,7 +70,7 @@ public class GraphEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task DraggingConnectionsWorks()
+    public void DraggingConnectionsWorks()
     {
         // SETUP
         var firstNode = _graphEdit.Nodes.First();
@@ -79,7 +78,7 @@ public class GraphEditDriverTest : DriverTest
 
         // WHEN
         // i drag a connection from the first node to the second node
-        await firstNode.DragConnection(Port.Output(0), secondNode, Port.Input(0));
+        firstNode.DragConnection(Port.Output(0), secondNode, Port.Input(0));
 
         // THEN
         // the connection works
@@ -87,7 +86,7 @@ public class GraphEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task DraggingConnectionsInReverseWorks()
+    public void DraggingConnectionsInReverseWorks()
     {
         // SETUP
         var firstNode = _graphEdit.Nodes.First();
@@ -95,7 +94,7 @@ public class GraphEditDriverTest : DriverTest
 
         // WHEN
         // i drag a connection from the second node to the first node
-        await secondNode.DragConnection(Port.Input(0), firstNode, Port.Output(0));
+        secondNode.DragConnection(Port.Input(0), firstNode, Port.Output(0));
 
         // THEN
         // the connection works
@@ -103,18 +102,18 @@ public class GraphEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task DisconnectingWorks()
+    public void DisconnectingWorks()
     {
         // SETUP
         var firstNode = _graphEdit.Nodes.First();
         var secondNode = _graphEdit.Nodes.Last();
 
         // make a connection
-        await firstNode.DragConnection(Port.Output(0), secondNode, Port.Input(0));
+        firstNode.DragConnection(Port.Output(0), secondNode, Port.Input(0));
 
         // WHEN
         // i disconnect the connection, by dragging it from the second node to the first node
-        await secondNode.DragConnection(Port.Input(0), firstNode, Port.Output(0));
+        secondNode.DragConnection(Port.Input(0), firstNode, Port.Output(0));
 
         // THEN
         // the connection is gone

--- a/GodotTestDriver.Tests/ItemListDriverTest.cs
+++ b/GodotTestDriver.Tests/ItemListDriverTest.cs
@@ -1,8 +1,7 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -38,12 +37,12 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task SelectingItemsWorks()
+    public void SelectingItemsWorks()
     {
         // WHEN
         // we select the first item
         var signalAwaiter = _itemList.GetSignalAwaiter(ItemList.SignalName.ItemSelected);
-        await _itemList.SelectItemWithText("Normal Item 1");
+        _itemList.SelectItemWithText("Normal Item 1");
 
         // THEN
         // the first item is selected
@@ -56,7 +55,7 @@ public class ItemListDriverTest : DriverTest
         // WHEN
         // we select the second item
         var signalAwaiter2 = _itemList.GetSignalAwaiter(ItemList.SignalName.ItemSelected);
-        await _itemList.SelectItemWithText("Normal Item 2");
+        _itemList.SelectItemWithText("Normal Item 2");
 
         // THEN
         // the second item is selected
@@ -68,14 +67,14 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task MultiSelectionWorks()
+    public void MultiSelectionWorks()
     {
         // WHEN
         // we select the first item
-        await _itemList.SelectItemWithText("Normal Item 1");
+        _itemList.SelectItemWithText("Normal Item 1");
 
         // and adding the second item
-        await _itemList.SelectItemWithText("Normal Item 2", true);
+        _itemList.SelectItemWithText("Normal Item 2", true);
 
         // THEN
         // both items are selected
@@ -85,11 +84,11 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task MassSelectionWorks()
+    public void MassSelectionWorks()
     {
         // WHEN
         // we select all items
-        await _itemList.SelectItemsWithText("Normal Item 1", "Normal Item 2");
+        _itemList.SelectItemsWithText("Normal Item 1", "Normal Item 2");
 
         // THEN
         // both items are selected
@@ -99,14 +98,14 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task DeselectionWorks()
+    public void DeselectionWorks()
     {
         // WHEN
         // we select the first item
-        await _itemList.SelectItemWithText("Normal Item 1");
+        _itemList.SelectItemWithText("Normal Item 1");
 
         // and deselect it
-        await _itemList.DeselectItemWithText("Normal Item 1");
+        _itemList.DeselectItemWithText("Normal Item 1");
 
         // THEN
         // no items are selected
@@ -114,15 +113,15 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task MassDeselectionWorks()
+    public void MassDeselectionWorks()
     {
         // WHEN
         // we select the two items
-        await _itemList.SelectItemWithText("Normal Item 1");
-        await _itemList.SelectItemWithText("Normal Item 2", true);
+        _itemList.SelectItemWithText("Normal Item 1");
+        _itemList.SelectItemWithText("Normal Item 2", true);
 
         // and deselect all
-        await _itemList.DeselectAll();
+        _itemList.DeselectAll();
 
         // THEN
         // no items are selected
@@ -130,12 +129,12 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task ActivatingItemsWorks()
+    public void ActivatingItemsWorks()
     {
         // WHEN
         // we activate the first item
         var signalAwaiter = _itemList.GetSignalAwaiter(ItemList.SignalName.ItemActivated);
-        await _itemList.ActivateItemWithText("Normal Item 1");
+        _itemList.ActivateItemWithText("Normal Item 1");
 
         // THEN
         // the signal is emitted
@@ -143,26 +142,26 @@ public class ItemListDriverTest : DriverTest
     }
 
     [Test]
-    public async Task SelectingDisabledItemsDoesNotWork()
+    public void SelectingDisabledItemsDoesNotWork()
     {
         // WHEN
         // we try to select a disabled item, an InvalidOperationException should be thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _itemList.SelectItemWithText("Disabled Item"));
+        Should.Throw<InvalidOperationException>(() => _itemList.SelectItemWithText("Disabled Item"));
     }
 
     [Test]
-    public async Task SelectingNonExistingItemsDoesNotWork()
+    public void SelectingNonExistingItemsDoesNotWork()
     {
         // WHEN
         // we try to select a non-existing item, an InvalidOperationException should be thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _itemList.SelectItemWithText("Non-existing Item"));
+        Should.Throw<InvalidOperationException>(() => _itemList.SelectItemWithText("Non-existing Item"));
     }
 
     [Test]
-    public async Task SelectingUnselectableItemsDoesNotWork()
+    public void SelectingUnselectableItemsDoesNotWork()
     {
         // WHEN
         // we try to select an unselectable item, an InvalidOperationException should be thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _itemList.SelectItemWithText("NonSelectable Item"));
+        Should.Throw<InvalidOperationException>(() => _itemList.SelectItemWithText("NonSelectable Item"));
     }
 }

--- a/GodotTestDriver.Tests/LineEditDriverTest.cs
+++ b/GodotTestDriver.Tests/LineEditDriverTest.cs
@@ -1,7 +1,6 @@
 namespace GodotTestDriver.Tests;
 
 using System;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -17,23 +16,23 @@ public class LineEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task TextChanges()
+    public void TextChanges()
     {
         // WHEN
         // i type "hello" into the line edit
-        await _lineEdit.Type("hello");
+        _lineEdit.Type("hello");
         // THEN
         // the text changes
         _lineEdit.Text.ShouldBe("hello");
     }
 
     [Test]
-    public async Task SubmittingTextSendsSignal()
+    public void SubmittingTextSendsSignal()
     {
         var awaiter = _lineEdit.GetSignalAwaiter(LineEdit.SignalName.TextSubmitted);
         // WHEN
         // i type "hello" into the line edit and press enter
-        await _lineEdit.Submit("hello");
+        _lineEdit.Submit("hello");
         // THEN
         // the text changes
         _lineEdit.Text.ShouldBe("hello");
@@ -42,7 +41,7 @@ public class LineEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task DisabledLineEditCannotBeEdited()
+    public void DisabledLineEditCannotBeEdited()
     {
         // SETUP
         _lineEdit.PresentRoot.Editable = false;
@@ -51,11 +50,11 @@ public class LineEditDriverTest : DriverTest
         // i try to type into the disabled line edit
         // THEN
         // an exception is thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _lineEdit.Type("hello"));
+        Should.Throw<InvalidOperationException>(() => _lineEdit.Type("hello"));
     }
 
     [Test]
-    public async Task DisabledLineEditCannotBeSubmitted()
+    public void DisabledLineEditCannotBeSubmitted()
     {
         // SETUP
         _lineEdit.PresentRoot.Editable = false;
@@ -64,11 +63,11 @@ public class LineEditDriverTest : DriverTest
         // i try to submit text into the disabled line edit
         // THEN
         // an exception is thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _lineEdit.Submit("hello"));
+        Should.Throw<InvalidOperationException>(() => _lineEdit.Submit("hello"));
     }
 
     [Test]
-    public async Task InvisibleLineEditCannotBeEdited()
+    public void InvisibleLineEditCannotBeEdited()
     {
         // SETUP
         _lineEdit.PresentRoot.Visible = false;
@@ -77,11 +76,11 @@ public class LineEditDriverTest : DriverTest
         // i try to type into the invisible line edit
         // THEN
         // an exception is thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _lineEdit.Type("hello"));
+        Should.Throw<InvalidOperationException>(() => _lineEdit.Type("hello"));
     }
 
     [Test]
-    public async Task InvisibleLineEditCannotBeSubmitted()
+    public void InvisibleLineEditCannotBeSubmitted()
     {
         // SETUP
         _lineEdit.PresentRoot.Visible = false;
@@ -90,6 +89,6 @@ public class LineEditDriverTest : DriverTest
         // i try to submit text into the invisible line edit
         // THEN
         // an exception is thrown
-        await Should.ThrowAsync<InvalidOperationException>(async () => await _lineEdit.Submit("hello"));
+        Should.Throw<InvalidOperationException>(() => _lineEdit.Submit("hello"));
     }
 }

--- a/GodotTestDriver.Tests/OptionButtonDriverTest.cs
+++ b/GodotTestDriver.Tests/OptionButtonDriverTest.cs
@@ -1,8 +1,7 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -33,12 +32,12 @@ public class OptionButtonDriverTest : DriverTest
     }
 
     [Test]
-    public async Task SelectingAnItemWorks()
+    public void SelectingAnItemWorks()
     {
         // WHEN
         // we select the first item
         var signalAwaiter = _optionButton.GetSignalAwaiter(OptionButton.SignalName.ItemSelected);
-        await _optionButton.SelectItemWithText("Normal Item 1");
+        _optionButton.SelectItemWithText("Normal Item 1");
 
         // THEN
         // the first item is selected
@@ -49,12 +48,12 @@ public class OptionButtonDriverTest : DriverTest
     }
 
     [Test]
-    public async Task SelectingANonExistingItemThrowsException()
+    public void SelectingANonExistingItemThrowsException()
     {
         // WHEN
         // we select a non-existing item
         var signalAwaiter = _optionButton.GetSignalAwaiter(OptionButton.SignalName.ItemSelected);
-        var exception = await Should.ThrowAsync<Exception>(async () => await _optionButton.SelectItemWithText("Non-existing Item"));
+        var exception = Should.Throw<Exception>(() => _optionButton.SelectItemWithText("Non-existing Item"));
 
         // THEN
         // the exception is thrown
@@ -65,12 +64,12 @@ public class OptionButtonDriverTest : DriverTest
     }
 
     [Test]
-    public async Task SelectingADisabledItemThrowsException()
+    public void SelectingADisabledItemThrowsException()
     {
         // WHEN
         // we select a disabled item
         var signalAwaiter = _optionButton.GetSignalAwaiter(OptionButton.SignalName.ItemSelected);
-        var exception = await Should.ThrowAsync<Exception>(async () => await _optionButton.SelectItemWithText("Disabled Item"));
+        var exception = Should.Throw<Exception>(() => _optionButton.SelectItemWithText("Disabled Item"));
 
         // THEN
         // the exception is thrown
@@ -81,12 +80,12 @@ public class OptionButtonDriverTest : DriverTest
     }
 
     [Test]
-    public async Task SelectingASeparatorThrowsException()
+    public void SelectingASeparatorThrowsException()
     {
         // WHEN
         // we select a separator
         var signalAwaiter = _optionButton.GetSignalAwaiter(OptionButton.SignalName.ItemSelected);
-        var exception = await Should.ThrowAsync<Exception>(async () => await _optionButton.SelectItemWithText("Separator"));
+        var exception = Should.Throw<Exception>(() => _optionButton.SelectItemWithText("Separator"));
 
         // THEN
         // the exception is thrown

--- a/GodotTestDriver.Tests/PopupMenuDriverTest.cs
+++ b/GodotTestDriver.Tests/PopupMenuDriverTest.cs
@@ -1,7 +1,6 @@
 namespace GodotTestDriver.Tests;
 
 using System.Linq;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -59,7 +58,7 @@ public class PopupMenuDriverTest : DriverTest
     // named "Normal Item 1" and "Normal Item 2"
 
     [Test]
-    public async Task SelectingAnItemWorks()
+    public void SelectingAnItemWorks()
     {
         // WHEN
         // we press the button
@@ -67,7 +66,7 @@ public class PopupMenuDriverTest : DriverTest
 
         // and we select the first item
         var signalAwaiter = _popupMenu.GetSignalAwaiter(PopupMenu.SignalName.IndexPressed);
-        await _popupMenu.SelectItemWithText("Normal Item 1");
+        _popupMenu.SelectItemWithText("Normal Item 1");
 
         // THEN
         // the popup menu should be hidden

--- a/GodotTestDriver.Tests/PopupMenuDriverTest.cs
+++ b/GodotTestDriver.Tests/PopupMenuDriverTest.cs
@@ -1,4 +1,4 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,11 +28,11 @@ public class PopupMenuDriverTest : DriverTest
     }
 
     [Test]
-    public async Task InspectionWorks()
+    public void InspectionWorks()
     {
         // WHEN
         // we press the button
-        await _button.Press();
+        _button.Press();
 
         // THEN
         // the popup menu is visible
@@ -63,7 +63,7 @@ public class PopupMenuDriverTest : DriverTest
     {
         // WHEN
         // we press the button
-        await _button.Press();
+        _button.Press();
 
         // and we select the first item
         var signalAwaiter = _popupMenu.GetSignalAwaiter(PopupMenu.SignalName.IndexPressed);

--- a/GodotTestDriver.Tests/TabContainerDriverTest.cs
+++ b/GodotTestDriver.Tests/TabContainerDriverTest.cs
@@ -1,9 +1,10 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
 using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
+using GodotTestDriver.Util;
 using JetBrains.Annotations;
 using Shouldly;
 
@@ -47,7 +48,9 @@ public class TabContainerDriverTest : DriverTest
     {
         // WHEN
         // the second tab is selected
-        await _tabContainer.SelectTabWithTitle("Second Tab");
+        _tabContainer.SelectTabWithTitle("Second Tab");
+        // and we've waited an additional frame for Godot to change visibility
+        await _tabContainer.PresentRoot.ProcessFrame();
 
         // THEN
         // the second tab is selected

--- a/GodotTestDriver.Tests/TextEditDriverTest.cs
+++ b/GodotTestDriver.Tests/TextEditDriverTest.cs
@@ -1,7 +1,6 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
 using System;
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -19,14 +18,14 @@ public class TextEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task TypingWorks()
+    public void TypingWorks()
     {
         // get the signal awaiter
         var signalAwaiter = _textEdit.GetSignalAwaiter(TextEdit.SignalName.TextChanged);
 
         // WHEN
         // i type "Hello World!" into the text edit
-        await _textEdit.Type("Hello World!");
+        _textEdit.Type("Hello World!");
 
         // THEN
         // the text edit text is "Hello World!"
@@ -37,7 +36,7 @@ public class TextEditDriverTest : DriverTest
     }
 
     [Test]
-    public async Task TypingThrowsExceptionIfNotEditable()
+    public void TypingThrowsExceptionIfNotEditable()
     {
         // GIVEN
         // the text edit is not editable
@@ -45,7 +44,7 @@ public class TextEditDriverTest : DriverTest
 
         // WHEN
         // i try to type "Hello World!" into the text edit
-        var exception = await Should.ThrowAsync<InvalidOperationException>(async () => await _textEdit.Type("Hello World!"));
+        var exception = Should.Throw<InvalidOperationException>(() => _textEdit.Type("Hello World!"));
 
         // THEN
         // the exception message is correct

--- a/GodotTestDriver.Tests/WindowDriverTest.cs
+++ b/GodotTestDriver.Tests/WindowDriverTest.cs
@@ -1,6 +1,5 @@
-﻿namespace GodotTestDriver.Tests;
+namespace GodotTestDriver.Tests;
 
-using System.Threading.Tasks;
 using Chickensoft.GoDotTest;
 using Godot;
 using GodotTestDriver.Drivers;
@@ -16,7 +15,7 @@ public class WindowDriverTest : DriverTest
     }
 
     [Test]
-    public async Task WindowClosingWorks()
+    public void WindowClosingWorks()
     {
         // GIVEN
         // the window is visible
@@ -24,7 +23,7 @@ public class WindowDriverTest : DriverTest
 
         // WHEN
         // i close the window
-        await _window.Close();
+        _window.Close();
 
         // THEN
         // the window is not visible
@@ -35,12 +34,12 @@ public class WindowDriverTest : DriverTest
     /// dragging the window works
     /// </summary>
     [Test]
-    public async Task WindowDraggingWorks()
+    public void WindowDraggingWorks()
     {
         var initialPosition = _window.Position;
         // WHEN
         // i drag the window
-        await _window.DragByPixels(100, 100);
+        _window.DragByPixels(100, 100);
 
         // THEN
         // the window is visible

--- a/GodotTestDriver.Tests/project.godot
+++ b/GodotTestDriver.Tests/project.godot
@@ -19,6 +19,13 @@ config/icon="res://icon.svg"
 
 project/assembly_name="GodotTestDriver.Tests"
 
+[input]
+
+test_action={
+"deadzone": 0.5,
+"events": []
+}
+
 [rendering]
 
 renderer/rendering_method="mobile"

--- a/GodotTestDriver/Drivers/BaseButtonDriver.cs
+++ b/GodotTestDriver/Drivers/BaseButtonDriver.cs
@@ -62,13 +62,13 @@ public class BaseButtonDriver<T> : ControlDriver<T> where T : BaseButton
     /// <param name="button">Mouse button.</param>
     /// <returns>Task that completes when the click finishes.</returns>
     /// <exception cref="InvalidOperationException" />
-    public override async Task ClickCenter(MouseButton button = MouseButton.Left)
+    public override void ClickCenter(MouseButton button = MouseButton.Left)
     {
         if (Disabled)
         {
             throw new InvalidOperationException(ErrorMessage("Button is disabled and cannot be pressed."));
         }
 
-        await base.ClickCenter(button);
+        base.ClickCenter(button);
     }
 }

--- a/GodotTestDriver/Drivers/BaseButtonDriver.cs
+++ b/GodotTestDriver/Drivers/BaseButtonDriver.cs
@@ -1,9 +1,7 @@
 namespace GodotTestDriver.Drivers;
 
 using System;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -41,7 +39,7 @@ public class BaseButtonDriver<T> : ControlDriver<T> where T : BaseButton
     ///  Simulates a button press by simply sending the press event.
     /// </summary>
     /// <exception cref="InvalidOperationException"/>
-    public async Task Press()
+    public void Press()
     {
         var button = VisibleRoot;
 
@@ -50,10 +48,7 @@ public class BaseButtonDriver<T> : ControlDriver<T> where T : BaseButton
             throw new InvalidOperationException(ErrorMessage("Button is disabled and cannot be pressed."));
         }
 
-        // make sure we run on main thread
-        await button.GetTree().NextFrame();
         button.EmitSignal(BaseButton.SignalName.Pressed);
-        await button.GetTree().WaitForEvents();
     }
 
     /// <summary>

--- a/GodotTestDriver/Drivers/Camera2DDriver.cs
+++ b/GodotTestDriver/Drivers/Camera2DDriver.cs
@@ -23,6 +23,18 @@ public class Camera2DDriver<T> : Node2DDriver<T> where T : Camera2D
     }
 
     /// <summary>
+    /// Starts moving the given position into the view of the camera. This does NOT wait for the camera to
+    /// finish moving.
+    /// </summary>
+    /// <param name="worldPosition">World position to move into view.</param>
+    /// <seealso cref="MoveIntoView(Vector2, float)"/>
+    /// <seealso cref="WaitUntilSteady(float)"/>
+    public void StartMoveIntoView(Vector2 worldPosition)
+    {
+        PresentRoot.GlobalPosition = worldPosition;
+    }
+
+    /// <summary>
     /// Moves the given position into the view of the camera. This will wait for the given amount of seconds
     /// until the camera no longer moves.
     /// </summary>
@@ -30,7 +42,7 @@ public class Camera2DDriver<T> : Node2DDriver<T> where T : Camera2D
     /// <param name="timeoutSeconds">Timeout, in seconds.</param>
     public async Task<bool> MoveIntoView(Vector2 worldPosition, float timeoutSeconds)
     {
-        PresentRoot.GlobalPosition = worldPosition;
+        StartMoveIntoView(worldPosition);
         return await WaitUntilSteady(timeoutSeconds);
     }
 

--- a/GodotTestDriver/Drivers/ControlDriver.cs
+++ b/GodotTestDriver/Drivers/ControlDriver.cs
@@ -66,22 +66,18 @@ public class ControlDriver<T> : CanvasItemDriver<T> where T : Control
     /// <summary>
     /// Instructs the control to release the focus.
     /// </summary>
-    public async Task ReleaseFocus()
+    public void ReleaseFocus()
     {
         var control = VisibleRoot;
-        await control.GetTree().NextFrame();
         control.ReleaseFocus();
-        await control.GetTree().WaitForEvents();
     }
 
     /// <summary>
     /// Instructs the control to grab the focus.
     /// </summary>
-    public async Task GrabFocus()
+    public void GrabFocus()
     {
         var control = VisibleRoot;
-        await control.GetTree().NextFrame();
         control.GrabFocus();
-        await control.GetTree().WaitForEvents();
     }
 }

--- a/GodotTestDriver/Drivers/ControlDriver.cs
+++ b/GodotTestDriver/Drivers/ControlDriver.cs
@@ -45,10 +45,10 @@ public class ControlDriver<T> : CanvasItemDriver<T> where T : Control
     /// Clicks the control with the mouse in the center.
     /// </summary>
     /// <param name="button">Mouse button.</param>
-    public virtual async Task ClickCenter(MouseButton button = MouseButton.Left)
+    public virtual void ClickCenter(MouseButton button = MouseButton.Left)
     {
         var control = VisibleRoot;
-        await control.GetViewport().ClickMouseAt(control.GetGlobalRect().Center(), button);
+        control.GetViewport().ClickMouseAt(control.GetGlobalRect().Center(), button);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public class ControlDriver<T> : CanvasItemDriver<T> where T : Control
     public async Task Hover(float seconds)
     {
         var control = VisibleRoot;
-        await control.GetViewport().MoveMouseTo(control.GetGlobalRect().Center());
+        control.GetViewport().MoveMouseTo(control.GetGlobalRect().Center());
         await control.SleepSeconds(seconds);
     }
 

--- a/GodotTestDriver/Drivers/GraphNodeDriver.cs
+++ b/GodotTestDriver/Drivers/GraphNodeDriver.cs
@@ -1,7 +1,6 @@
 namespace GodotTestDriver.Drivers;
 
 using System;
-using System.Threading.Tasks;
 using Godot;
 using GodotTestDriver.Input;
 using JetBrains.Annotations;
@@ -99,13 +98,13 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
     /// Drags the node by the given amount of pixels.
     /// </summary>
     /// <param name="delta">Change in distance.</param>
-    public async Task DragBy(Vector2 delta)
+    public void DragBy(Vector2 delta)
     {
         var dragStart = SelectionSpot;
         var dragEnd = dragStart + delta;
 
         // drag it
-        await Viewport.DragMouse(dragStart, dragEnd);
+        Viewport.DragMouse(dragStart, dragEnd);
     }
 
     /// <summary>
@@ -113,21 +112,21 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
     /// </summary>
     /// <param name="x">Horizontal cartesian coordinate component.</param>
     /// <param name="y">Vertical cartesian coordinate component.</param>
-    public async Task DragBy(float x, float y)
+    public void DragBy(float x, float y)
     {
-        await DragBy(new Vector2(x, y));
+        DragBy(new Vector2(x, y));
     }
 
     /// <summary>
     /// Drags the node by a multiple of its own size multiplied by the given factor.
     /// </summary>
     /// <param name="delta">Change in distance.</param>
-    public async Task DragByOwnSize(Vector2 delta)
+    public void DragByOwnSize(Vector2 delta)
     {
         var node = VisibleRoot;
         var rect = node.GetRect();
 
-        await DragBy(new Vector2(rect.Size.X * delta.X, rect.Size.X * delta.Y));
+        DragBy(new Vector2(rect.Size.X * delta.X, rect.Size.X * delta.Y));
     }
 
     /// <summary>
@@ -135,26 +134,26 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
     /// </summary>
     /// <param name="x">Horizontal cartesian coordinate component.</param>
     /// <param name="y">Vertical cartesian coordinate component.</param>
-    public async Task DragByOwnSize(float x, float y)
+    public void DragByOwnSize(float x, float y)
     {
-        await DragByOwnSize(new Vector2(x, y));
+        DragByOwnSize(new Vector2(x, y));
     }
 
     /// <summary>
     /// Selects the given node by clicking on it. Same as <see cref="ClickAtSelectionSpot"/>.
     /// </summary>
-    public async Task Select()
+    public void Select()
     {
-        await ClickAtSelectionSpot();
+        ClickAtSelectionSpot();
     }
 
     /// <summary>
     /// Clicks the mouse at the safe selection spot of this graph node.
     /// </summary>
     /// <param name="button">Button to use.</param>
-    public async Task ClickAtSelectionSpot(MouseButton button = MouseButton.Left)
+    public void ClickAtSelectionSpot(MouseButton button = MouseButton.Left)
     {
-        await Viewport.ClickMouseAt(SelectionSpot, button);
+        Viewport.ClickMouseAt(SelectionSpot, button);
     }
 
     /// <summary>
@@ -164,7 +163,7 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
     /// <param name="targetNode">Target node.</param>
     /// <param name="targetPort">Target node connection port.</param>
     /// <exception cref="ArgumentException"/>
-    public async Task DragConnection(Port sourcePort, GraphNodeDriver<T> targetNode, Port targetPort)
+    public void DragConnection(Port sourcePort, GraphNodeDriver<T> targetNode, Port targetPort)
     {
         if (!sourcePort.IsDefined)
         {
@@ -208,7 +207,7 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
             ? targetRoot.GetInputPortPosition(targetPort.PortIndex)
             : targetRoot.GetOutputPortPosition(targetPort.PortIndex);
 
-        await Viewport.DragMouse(startPosition + thisRoot.GlobalPosition,
+        Viewport.DragMouse(startPosition + thisRoot.GlobalPosition,
             endPosition + targetRoot.GlobalPosition);
     }
 
@@ -218,7 +217,7 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
     /// <param name="sourcePort">Source port.</param>
     /// <param name="relativePosition">Position offset.</param>
     /// <exception cref="ArgumentException"/>
-    public async Task DragConnection(Port sourcePort, Vector2 relativePosition)
+    public void DragConnection(Port sourcePort, Vector2 relativePosition)
     {
         if (!sourcePort.IsDefined)
         {
@@ -242,7 +241,7 @@ public class GraphNodeDriver<T> : ControlDriver<T> where T : GraphNode
             : thisRoot.GetOutputPortPosition(sourcePort.PortIndex);
         var endPosition = startPosition + relativePosition;
 
-        await Viewport.DragMouse(startPosition + thisRoot.GlobalPosition,
+        Viewport.DragMouse(startPosition + thisRoot.GlobalPosition,
             endPosition + thisRoot.GlobalPosition);
     }
 }

--- a/GodotTestDriver/Drivers/ItemListDriver.cs
+++ b/GodotTestDriver/Drivers/ItemListDriver.cs
@@ -3,9 +3,7 @@ namespace GodotTestDriver.Drivers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -106,7 +104,7 @@ public class ItemListDriver<T> : ControlDriver<T> where T : ItemList
     /// <param name="text">Item label.</param>
     /// <param name="addToSelection">True to add to the current selection, false to change the selection.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task SelectItemWithText(string text, bool addToSelection = false)
+    public void SelectItemWithText(string text, bool addToSelection = false)
     {
         var uiControl = VisibleRoot;
 
@@ -115,7 +113,6 @@ public class ItemListDriver<T> : ControlDriver<T> where T : ItemList
             throw new InvalidOperationException(ErrorMessage("Cannot select multiple items because selection mode is not allowing it."));
         }
 
-        await uiControl.GetTree().NextFrame();
         var i = IndexOf(text);
         if (!uiControl.IsItemSelectable(i) || uiControl.IsItemDisabled(i))
         {
@@ -132,19 +129,17 @@ public class ItemListDriver<T> : ControlDriver<T> where T : ItemList
         {
             uiControl.EmitSignal(ItemList.SignalName.ItemSelected, i);
         }
-
-        await uiControl.GetTree().WaitForEvents();
     }
 
     /// <summary>
     /// Selects multiple items with the given texts.
     /// </summary>
     /// <param name="texts">Item label.</param>
-    public async Task SelectItemsWithText(IEnumerable<string> texts)
+    public void SelectItemsWithText(IEnumerable<string> texts)
     {
         foreach (var text in texts)
         {
-            await SelectItemWithText(text, true);
+            SelectItemWithText(text, true);
         }
     }
 
@@ -152,9 +147,9 @@ public class ItemListDriver<T> : ControlDriver<T> where T : ItemList
     /// Selects multiple items with the given texts.
     /// </summary>
     /// <param name="texts">Item labels.</param>
-    public async Task SelectItemsWithText(params string[] texts)
+    public void SelectItemsWithText(params string[] texts)
     {
-        await SelectItemsWithText(texts.AsEnumerable());
+        SelectItemsWithText(texts.AsEnumerable());
     }
 
     /// <summary>
@@ -162,10 +157,9 @@ public class ItemListDriver<T> : ControlDriver<T> where T : ItemList
     /// </summary>
     /// <param name="text">Item label.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task DeselectItemWithText(string text)
+    public void DeselectItemWithText(string text)
     {
         var uiControl = VisibleRoot;
-        await uiControl.GetTree().NextFrame();
 
         var i = IndexOf(text);
         if (!uiControl.IsItemSelectable(i) || uiControl.IsItemDisabled(i))
@@ -174,32 +168,28 @@ public class ItemListDriver<T> : ControlDriver<T> where T : ItemList
         }
 
         uiControl.Deselect(i);
-        await uiControl.GetTree().WaitForEvents();
     }
 
     /// <summary>
     /// Deselects all items.
     /// </summary>
-    public async Task DeselectAll()
+    public void DeselectAll()
     {
         var uiControl = VisibleRoot;
-        await uiControl.GetTree().NextFrame();
         uiControl.DeselectAll();
-        await uiControl.GetTree().WaitForEvents();
     }
 
     /// <summary>
     /// Activates the item with the given text.
     /// </summary>
     /// <param name="text">Item label.</param>
-    public async Task ActivateItemWithText(string text)
+    public void ActivateItemWithText(string text)
     {
         var uiControl = VisibleRoot;
-        await SelectItemWithText(text);
+        SelectItemWithText(text);
 
         // send the activation signal
         uiControl.EmitSignal(ItemList.SignalName.ItemActivated, IndexOf(text));
-        await uiControl.GetTree().WaitForEvents();
     }
 }
 

--- a/GodotTestDriver/Drivers/LineEditDriver.cs
+++ b/GodotTestDriver/Drivers/LineEditDriver.cs
@@ -46,7 +46,7 @@ public class LineEditDriver<T> : ControlDriver<T> where T : LineEdit
 
         var edit = VisibleRoot;
         await edit.GetTree().NextFrame();
-        await ClickCenter();
+        ClickCenter();
         edit.Text = text;
         edit.EmitSignal(LineEdit.SignalName.TextChanged, text);
         await edit.GetTree().WaitForEvents();

--- a/GodotTestDriver/Drivers/LineEditDriver.cs
+++ b/GodotTestDriver/Drivers/LineEditDriver.cs
@@ -1,9 +1,7 @@
 namespace GodotTestDriver.Drivers;
 
 using System;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -37,7 +35,7 @@ public class LineEditDriver<T> : ControlDriver<T> where T : LineEdit
     /// </summary>
     /// <param name="text">Text contents.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task Type(string text)
+    public void Type(string text)
     {
         if (!Editable)
         {
@@ -45,11 +43,9 @@ public class LineEditDriver<T> : ControlDriver<T> where T : LineEdit
         }
 
         var edit = VisibleRoot;
-        await edit.GetTree().NextFrame();
         ClickCenter();
         edit.Text = text;
         edit.EmitSignal(LineEdit.SignalName.TextChanged, text);
-        await edit.GetTree().WaitForEvents();
     }
 
     /// <summary>
@@ -57,7 +53,7 @@ public class LineEditDriver<T> : ControlDriver<T> where T : LineEdit
     /// </summary>
     /// <param name="text">Text contents.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task Submit(string text)
+    public void Submit(string text)
     {
         if (!Editable)
         {
@@ -66,10 +62,9 @@ public class LineEditDriver<T> : ControlDriver<T> where T : LineEdit
 
         var edit = VisibleRoot;
         // first type the text, so the text change events are triggered
-        await Type(text);
+        Type(text);
         // then send the "TextSubmitted" event
         edit.EmitSignal(LineEdit.SignalName.TextSubmitted, text);
-        await edit.GetTree().WaitForEvents();
     }
 }
 

--- a/GodotTestDriver/Drivers/OptionButtonDriver.cs
+++ b/GodotTestDriver/Drivers/OptionButtonDriver.cs
@@ -2,9 +2,7 @@ namespace GodotTestDriver.Drivers;
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -109,15 +107,13 @@ public class OptionButtonDriver<T> : BaseButtonDriver<T> where T : OptionButton
     /// Selects an item with the given text.
     /// </summary>
     /// <param name="text">Option label.</param>
-    public async Task SelectItemWithText(string text)
+    public void SelectItemWithText(string text)
     {
         var uiControl = VisibleRoot;
-        await uiControl.GetTree().NextFrame();
         var index = IndexOf(text);
         uiControl.Select(index);
         // calling this function will not emit the signal so we need to do this ourselves
         uiControl.EmitSignal(OptionButton.SignalName.ItemSelected, index);
-        await uiControl.GetTree().WaitForEvents();
     }
 
     /// <summary>
@@ -125,10 +121,9 @@ public class OptionButtonDriver<T> : BaseButtonDriver<T> where T : OptionButton
     /// </summary>
     /// <param name="id">Option id.</param>
     /// <exception cref="InvalidOperationException" />
-    public async Task SelectItemWithId(int id)
+    public void SelectItemWithId(int id)
     {
         var uiControl = VisibleRoot;
-        await uiControl.GetTree().NextFrame();
 
         for (var i = 0; i < uiControl.ItemCount; i++)
         {
@@ -145,7 +140,6 @@ public class OptionButtonDriver<T> : BaseButtonDriver<T> where T : OptionButton
             uiControl.Select(i);
             // calling this function will not emit the signal so we need to do this ourselves
             uiControl.EmitSignal(OptionButton.SignalName.ItemSelected, i);
-            await uiControl.GetTree().WaitForEvents();
             return;
         }
 

--- a/GodotTestDriver/Drivers/PopupMenuDriver.cs
+++ b/GodotTestDriver/Drivers/PopupMenuDriver.cs
@@ -2,9 +2,7 @@ namespace GodotTestDriver.Drivers;
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -165,7 +163,7 @@ public class PopupMenuDriver<T> : WindowDriver<T> where T : PopupMenu
     /// </summary>
     /// <param name="index">Menu item index.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task SelectItemAtIndex(int index)
+    public void SelectItemAtIndex(int index)
     {
         var popup = VisibleRoot;
         VerifyIndex(index);
@@ -184,14 +182,11 @@ public class PopupMenuDriver<T> : WindowDriver<T> where T : PopupMenu
                 $"Item at index {index} is a separator and cannot be selected.");
         }
 
-        await popup.GetTree().NextFrame();
-
         // select item
         // ideally we would use a mouse click here but since the API does not provide the position of
         // each entry, we have to fake it.
         popup.EmitSignal(PopupMenu.SignalName.IndexPressed, index);
         popup.Hide();
-        await popup.GetTree().WaitForEvents();
     }
 
     /// <summary>
@@ -214,7 +209,7 @@ public class PopupMenuDriver<T> : WindowDriver<T> where T : PopupMenu
     /// </summary>
     /// <param name="id">Menu item id.</param>
     /// <exception cref="InvalidOperationException" />
-    public async Task SelectItemWithId(int id)
+    public void SelectItemWithId(int id)
     {
         var popup = PresentRoot;
         for (var i = 0; i < ItemCount; i++)
@@ -223,7 +218,7 @@ public class PopupMenuDriver<T> : WindowDriver<T> where T : PopupMenu
             {
                 continue;
             }
-            await SelectItemAtIndex(i);
+            SelectItemAtIndex(i);
             return;
         }
 
@@ -236,7 +231,7 @@ public class PopupMenuDriver<T> : WindowDriver<T> where T : PopupMenu
     /// </summary>
     /// <param name="text">Menu item label.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task SelectItemWithText(string text)
+    public void SelectItemWithText(string text)
     {
         var popup = PresentRoot;
         for (var i = 0; i < ItemCount; i++)
@@ -245,7 +240,7 @@ public class PopupMenuDriver<T> : WindowDriver<T> where T : PopupMenu
             {
                 continue;
             }
-            await SelectItemAtIndex(i);
+            SelectItemAtIndex(i);
             return;
         }
 

--- a/GodotTestDriver/Drivers/TabContainerDriver.cs
+++ b/GodotTestDriver/Drivers/TabContainerDriver.cs
@@ -3,9 +3,7 @@ namespace GodotTestDriver.Drivers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -56,9 +54,10 @@ public class TabContainerDriver<T> : ControlDriver<T> where T : TabContainer
     /// <summary>
     /// Selects the tab with the given index.
     /// </summary>
+    /// <remarks>Note that Godot requires one additional frame to set visibility of contents.</remarks>
     /// <param name="index">Tab index.</param>
     /// <exception cref="ArgumentOutOfRangeException"/>
-    public async Task SelectTabWithIndex(int index)
+    public void SelectTabWithIndex(int index)
     {
         var tab = VisibleRoot;
 
@@ -68,7 +67,6 @@ public class TabContainerDriver<T> : ControlDriver<T> where T : TabContainer
                 "Index must be between 0 and the amount of tabs in the tab control.");
         }
 
-        await tab.GetTree().NextFrame();
         var previousTab = tab.CurrentTab;
 
         tab.CurrentTab = index;
@@ -79,16 +77,15 @@ public class TabContainerDriver<T> : ControlDriver<T> where T : TabContainer
         {
             tab.EmitSignal(TabContainer.SignalName.TabChanged, index);
         }
-
-        await tab.GetTree().WaitForEvents();
     }
 
     /// <summary>
     /// Selects the tab with the given title
     /// </summary>
+    /// <remarks>Note that Godot requires one additional frame to set visibility of contents.</remarks>
     /// <param name="title">Tab label.</param>
     /// <exception cref="ArgumentException"/>
-    public async Task SelectTabWithTitle(string title)
+    public void SelectTabWithTitle(string title)
     {
         var index = TabTitles.ToList().IndexOf(title);
         if (index < 0)
@@ -96,7 +93,7 @@ public class TabContainerDriver<T> : ControlDriver<T> where T : TabContainer
             throw new ArgumentException($"No tab with the title '{title}' was found.", nameof(title));
         }
 
-        await SelectTabWithIndex(index);
+        SelectTabWithIndex(index);
     }
 }
 

--- a/GodotTestDriver/Drivers/TextEditDriver.cs
+++ b/GodotTestDriver/Drivers/TextEditDriver.cs
@@ -48,7 +48,7 @@ public class TextEditDriver<T> : ControlDriver<T> where T : TextEdit
 
         var edit = VisibleRoot;
         await edit.GetTree().NextFrame();
-        await ClickCenter();
+        ClickCenter();
         edit.Text = text;
         edit.EmitSignal(TextEdit.SignalName.TextChanged, text);
         await edit.GetTree().WaitForEvents();

--- a/GodotTestDriver/Drivers/TextEditDriver.cs
+++ b/GodotTestDriver/Drivers/TextEditDriver.cs
@@ -1,9 +1,7 @@
 namespace GodotTestDriver.Drivers;
 
 using System;
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -38,7 +36,7 @@ public class TextEditDriver<T> : ControlDriver<T> where T : TextEdit
     /// <param name="text">Text to input.</param>
     /// <returns>Task that completes when the input finishes.</returns>
     /// <exception cref="InvalidOperationException" />
-    public async Task Type(string text)
+    public void Type(string text)
     {
         if (ReadOnly)
         {
@@ -47,11 +45,9 @@ public class TextEditDriver<T> : ControlDriver<T> where T : TextEdit
         }
 
         var edit = VisibleRoot;
-        await edit.GetTree().NextFrame();
         ClickCenter();
         edit.Text = text;
         edit.EmitSignal(TextEdit.SignalName.TextChanged, text);
-        await edit.GetTree().WaitForEvents();
     }
 }
 

--- a/GodotTestDriver/Drivers/WindowDriver.cs
+++ b/GodotTestDriver/Drivers/WindowDriver.cs
@@ -54,7 +54,7 @@ public class WindowDriver<T> : NodeDriver<T> where T : Window
     }
 
     /// <summary>
-    /// Closes the window by clicking the close button.
+    /// Closes the window.
     /// </summary>
     public void Close()
     {

--- a/GodotTestDriver/Drivers/WindowDriver.cs
+++ b/GodotTestDriver/Drivers/WindowDriver.cs
@@ -1,10 +1,8 @@
 namespace GodotTestDriver.Drivers;
 
 using System;
-using System.Threading.Tasks;
 using Godot;
 using GodotTestDriver.Input;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -58,12 +56,10 @@ public class WindowDriver<T> : NodeDriver<T> where T : Window
     /// <summary>
     /// Closes the window by clicking the close button.
     /// </summary>
-    public async Task Close()
+    public void Close()
     {
         var window = VisibleRoot;
-        await window.GetTree().NextFrame();
         window.EmitSignal(Window.SignalName.CloseRequested);
-        await window.GetTree().WaitForEvents();
     }
 
     /// <summary>
@@ -71,9 +67,9 @@ public class WindowDriver<T> : NodeDriver<T> where T : Window
     /// </summary>
     /// <param name="x">Horizontal cartesian coordinate component.</param>
     /// <param name="y">Vertical cartesian coordinate component.</param>
-    public async Task DragByPixels(int x, int y)
+    public void DragByPixels(int x, int y)
     {
-        await DragByPixels(new Vector2I(x, y));
+        DragByPixels(new Vector2I(x, y));
     }
 
     /// <summary>
@@ -81,7 +77,7 @@ public class WindowDriver<T> : NodeDriver<T> where T : Window
     /// </summary>
     /// <param name="offset">Offset vector.</param>
     /// <exception cref="InvalidOperationException"/>
-    public async Task DragByPixels(Vector2I offset)
+    public void DragByPixels(Vector2I offset)
     {
         var window = VisibleRoot;
 
@@ -90,8 +86,6 @@ public class WindowDriver<T> : NodeDriver<T> where T : Window
         {
             throw new InvalidOperationException(ErrorMessage("Dragging of root windows is not supported."));
         }
-
-        await window.GetTree().NextFrame();
 
         var titleBarHeight = window.GetThemeConstant("title_height");
 

--- a/GodotTestDriver/Drivers/WindowDriver.cs
+++ b/GodotTestDriver/Drivers/WindowDriver.cs
@@ -1,4 +1,4 @@
-﻿namespace GodotTestDriver.Drivers;
+namespace GodotTestDriver.Drivers;
 
 using System;
 using System.Threading.Tasks;
@@ -103,7 +103,7 @@ public class WindowDriver<T> : NodeDriver<T> where T : Window
         var startSpot = new Vector2(pos.X + (width / 2f), pos.Y - (titleBarHeight / 2f));
         var endSpot = startSpot + offset;
 
-        await window.GetParent().GetViewport().DragMouse(startSpot, endSpot);
+        window.GetParent().GetViewport().DragMouse(startSpot, endSpot);
     }
 }
 

--- a/GodotTestDriver/Fixture.cs
+++ b/GodotTestDriver/Fixture.cs
@@ -43,7 +43,6 @@ public class Fixture
     /// fixture's <see cref="Cleanup" /> method is called. Note that it will _not_ be freed.</param>
     public async Task<T> AddToRoot<T>(T node, bool autoRemoveFromRoot = true) where T : Node
     {
-        await Tree.NextFrame();
         Tree.Root.AddChild(node);
 
         if (autoRemoveFromRoot)
@@ -57,7 +56,7 @@ public class Fixture
             });
         }
 
-        await Tree.WaitForEvents(); // make sure _Ready is called.
+        await Tree.NextFrame(); // make sure _Ready is called.
         return node;
     }
 

--- a/GodotTestDriver/Fixture.cs
+++ b/GodotTestDriver/Fixture.cs
@@ -73,7 +73,7 @@ public class Fixture
     /// <paramref name="autoFree"/> is also set to true.</param>
     public async Task<T> LoadAndAddScene<T>(string path, bool autoFree = true, bool autoRemoveFromRoot = true) where T : Node
     {
-        var instance = await LoadScene<T>(path, autoFree);
+        var instance = LoadScene<T>(path, autoFree);
         return await AddToRoot(instance, !autoFree && autoRemoveFromRoot);
     }
 
@@ -88,7 +88,7 @@ public class Fixture
     /// <paramref name="autoFree"/> is also set to true.</param>
     public async Task<T> LoadAndAddScene<T>(bool autoFree = true, bool autoRemoveFromRoot = true) where T : Node
     {
-        var instance = await LoadScene<T>(autoFree);
+        var instance = LoadScene<T>(autoFree);
         return await AddToRoot(instance, !autoFree && autoRemoveFromRoot);
     }
 
@@ -102,17 +102,15 @@ public class Fixture
     /// <returns>Instantiated scene.</returns>
     /// <exception cref="InvalidOperationException">Thrown when type does not have a
     /// <see cref="ScriptPathAttribute" />.</exception>
-    public async Task<T> LoadScene<T>(bool autoFree = true) where T : Node
+    public T LoadScene<T>(bool autoFree = true) where T : Node
     {
-        // make sure we run in the main thread
-        await Tree.NextFrame();
         // get script path given to a class by the Godot source generators.
         var attr = typeof(T).GetCustomAttribute<ScriptPathAttribute>()
             ?? throw new InvalidOperationException(
                 $"Type '{typeof(T)}' does not have a ScriptPathAttribute"
             );
         var path = Path.ChangeExtension(attr.Path, ".tscn");
-        return await LoadScene<T>(path, autoFree);
+        return LoadScene<T>(path, autoFree);
     }
 
     /// <summary>
@@ -123,11 +121,8 @@ public class Fixture
     /// <param name="autoFree">if set to true, the instance will be automatically freed when the fixture's
     /// <see cref="Cleanup" /> method is called</param>
     /// <exception cref="ArgumentException"></exception>
-    public async Task<T> LoadScene<T>(string path, bool autoFree = true) where T : Node
+    public T LoadScene<T>(string path, bool autoFree = true) where T : Node
     {
-        // make sure we run in the main thread
-        await Tree.NextFrame();
-
         var scene = GD.Load<PackedScene>(path);
         if (!Object.IsInstanceValid(scene))
         {

--- a/GodotTestDriver/Input/ActionsControlExtensions.cs
+++ b/GodotTestDriver/Input/ActionsControlExtensions.cs
@@ -42,6 +42,7 @@ public static class ActionsControlExtensions
             Action = actionName,
             Pressed = true
         });
+        Input.ActionPress(actionName);
         await node.GetTree().WaitForEvents();
     }
 
@@ -58,6 +59,7 @@ public static class ActionsControlExtensions
             Action = actionName,
             Pressed = false
         });
+        Input.ActionRelease(actionName);
         await node.GetTree().WaitForEvents();
     }
 

--- a/GodotTestDriver/Input/ActionsControlExtensions.cs
+++ b/GodotTestDriver/Input/ActionsControlExtensions.cs
@@ -24,18 +24,18 @@ public static class ActionsControlExtensions
         string actionName
     )
     {
-        await node.StartAction(actionName);
+        node.StartAction(actionName);
         await node.Wait(seconds);
-        await node.EndAction(actionName);
+        node.EndAction(actionName);
     }
 
     /// <summary>
     /// Start an input action.
     /// </summary>
-    /// <param name="node">Node to supply input to.</param>
+    /// <param name="_">Node to supply input to.</param>
     /// <param name="actionName">Name of the action.</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task StartAction(this Node node, string actionName)
+    public static void StartAction(this Node _, string actionName)
     {
         Input.ParseInputEvent(new InputEventAction
         {
@@ -43,16 +43,16 @@ public static class ActionsControlExtensions
             Pressed = true
         });
         Input.ActionPress(actionName);
-        await node.GetTree().WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
     /// <summary>
     /// End an input action.
     /// </summary>
-    /// <param name="node">Node to supply input to.</param>
+    /// <param name="_">Node to supply input to.</param>
     /// <param name="actionName">Name of the action.</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task EndAction(this Node node, string actionName)
+    public static void EndAction(this Node _, string actionName)
     {
         Input.ParseInputEvent(new InputEventAction
         {
@@ -60,7 +60,7 @@ public static class ActionsControlExtensions
             Pressed = false
         });
         Input.ActionRelease(actionName);
-        await node.GetTree().WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
     /// <summary>
@@ -69,9 +69,9 @@ public static class ActionsControlExtensions
     /// <param name="node">Node to supply input to.</param>
     /// <param name="actionName">Name of the action.</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task TriggerAction(this Node node, string actionName)
+    public static void TriggerAction(this Node node, string actionName)
     {
-        await node.StartAction(actionName);
-        await node.EndAction(actionName);
+        node.StartAction(actionName);
+        node.EndAction(actionName);
     }
 }

--- a/GodotTestDriver/Input/KeyboardControlExtensions.cs
+++ b/GodotTestDriver/Input/KeyboardControlExtensions.cs
@@ -20,7 +20,6 @@ public static class KeyboardControlExtensions
     /// <param name="alt">Alt modifier.</param>
     /// <param name="shift">Shift modifier.</param>
     /// <param name="meta">Meta-key (Windows, Command) modifier.</param>
-    /// <returns>Asynchronous task completed when key is released.</returns>
     public static void PressKey(
         this Node _,
         Key key,
@@ -79,7 +78,6 @@ public static class KeyboardControlExtensions
     /// <param name="alt">Alt modifier.</param>
     /// <param name="shift">Shift modifier.</param>
     /// <param name="meta">Meta-key (Windows, Command) modifier.</param>
-    /// <returns>Asynchronous task completed when key is released.</returns>
     public static void ReleaseKey(
         this Node _,
         Key key,
@@ -112,7 +110,6 @@ public static class KeyboardControlExtensions
     /// <param name="alt">Alt modifier.</param>
     /// <param name="shift">Shift modifier.</param>
     /// <param name="meta">Meta-key (Windows, Command) modifier.</param>
-    /// <returns>Asynchronous task completed when key is released.</returns>
     public static void TypeKey(
         this Node node,
         Key key,

--- a/GodotTestDriver/Input/KeyboardControlExtensions.cs
+++ b/GodotTestDriver/Input/KeyboardControlExtensions.cs
@@ -14,15 +14,15 @@ public static class KeyboardControlExtensions
     /// <summary>
     /// Presses the given key with the given modifiers.
     /// </summary>
-    /// <param name="node">Node to perform input on.</param>
+    /// <param name="_">Node to perform input on.</param>
     /// <param name="key">Keyboard key.</param>
     /// <param name="control">Control modifier.</param>
     /// <param name="alt">Alt modifier.</param>
     /// <param name="shift">Shift modifier.</param>
     /// <param name="meta">Meta-key (Windows, Command) modifier.</param>
     /// <returns>Asynchronous task completed when key is released.</returns>
-    public static async Task PressKey(
-        this Node node,
+    public static void PressKey(
+        this Node _,
         Key key,
         bool control = false,
         bool alt = false,
@@ -41,8 +41,7 @@ public static class KeyboardControlExtensions
         };
 
         Input.ParseInputEvent(inputEvent);
-
-        await node.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
     /// <summary>
@@ -66,23 +65,23 @@ public static class KeyboardControlExtensions
         bool meta = false
     )
     {
-        await node.PressKey(key, control, alt, shift, meta);
+        node.PressKey(key, control, alt, shift, meta);
         await node.Wait(seconds);
-        await node.ReleaseKey(key, control, alt, shift, meta);
+        node.ReleaseKey(key, control, alt, shift, meta);
     }
 
     /// <summary>
     /// Releases the given key with the given modifier state.
     /// </summary>
-    /// <param name="node">Node to perform input on.</param>
+    /// <param name="_">Node to perform input on.</param>
     /// <param name="key">Keyboard key.</param>
     /// <param name="control">Control modifier.</param>
     /// <param name="alt">Alt modifier.</param>
     /// <param name="shift">Shift modifier.</param>
     /// <param name="meta">Meta-key (Windows, Command) modifier.</param>
     /// <returns>Asynchronous task completed when key is released.</returns>
-    public static async Task ReleaseKey(
-        this Node node,
+    public static void ReleaseKey(
+        this Node _,
         Key key,
         bool control = false,
         bool alt = false,
@@ -101,8 +100,7 @@ public static class KeyboardControlExtensions
         };
 
         Input.ParseInputEvent(inputEvent);
-
-        await node.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
     /// <summary>
@@ -115,7 +113,7 @@ public static class KeyboardControlExtensions
     /// <param name="shift">Shift modifier.</param>
     /// <param name="meta">Meta-key (Windows, Command) modifier.</param>
     /// <returns>Asynchronous task completed when key is released.</returns>
-    public static async Task TypeKey(
+    public static void TypeKey(
         this Node node,
         Key key,
         bool control = false,
@@ -124,7 +122,7 @@ public static class KeyboardControlExtensions
         bool meta = false
     )
     {
-        await node.PressKey(key, control, alt, shift, meta);
-        await node.ReleaseKey(key, control, alt, shift, meta);
+        node.PressKey(key, control, alt, shift, meta);
+        node.ReleaseKey(key, control, alt, shift, meta);
     }
 }

--- a/GodotTestDriver/Input/MouseControlExtensions.cs
+++ b/GodotTestDriver/Input/MouseControlExtensions.cs
@@ -1,8 +1,6 @@
 namespace GodotTestDriver.Input;
 
-using System.Threading.Tasks;
 using Godot;
-using GodotTestDriver.Util;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -18,10 +16,10 @@ public static class MouseControlExtensions
     /// <param name="position">Position, in viewport coordinates.</param>
     /// <param name="button">Mouse button.</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task ClickMouseAt(this Viewport viewport, Vector2 position, MouseButton button = MouseButton.Left)
+    public static void ClickMouseAt(this Viewport viewport, Vector2 position, MouseButton button = MouseButton.Left)
     {
-        await viewport.PressMouseAt(position, button);
-        await viewport.ReleaseMouseAt(position, button);
+        viewport.PressMouseAt(position, button);
+        viewport.ReleaseMouseAt(position, button);
     }
 
     /// <summary>
@@ -30,19 +28,18 @@ public static class MouseControlExtensions
     /// <param name="viewport">Viewport.</param>
     /// <param name="position">Position, in viewport coordinates.</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task MoveMouseTo(this Viewport viewport, Vector2 position)
+    public static void MoveMouseTo(this Viewport viewport, Vector2 position)
     {
-        await viewport.ProcessFrame();
-
+        var oldPosition = viewport.GetMousePosition();
         viewport.WarpMouse(position);
         var inputEvent = new InputEventMouseMotion
         {
             GlobalPosition = position,
-            Position = position
+            Position = position,
+            Relative = position - oldPosition
         };
         Input.ParseInputEvent(inputEvent);
-
-        await viewport.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
     /// <summary>
@@ -53,55 +50,49 @@ public static class MouseControlExtensions
     /// <param name="end">End position, in viewport coordinates.</param>
     /// <param name="button">Mouse button.</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task DragMouse(this Viewport viewport, Vector2 start, Vector2 end, MouseButton button = MouseButton.Left)
+    public static void DragMouse(this Viewport viewport, Vector2 start, Vector2 end, MouseButton button = MouseButton.Left)
     {
-        await viewport.PressMouseAt(start, button);
-        await viewport.ReleaseMouseAt(end, button);
+        viewport.PressMouseAt(start, button);
+        viewport.ReleaseMouseAt(end, button);
     }
 
     /// <summary>
     /// Presses the given mouse button.
     /// </summary>
-    /// <param name="viewport">Viewport.</param>
+    /// <param name="_">Viewport.</param>
     /// <param name="button">Mouse button (left by default).</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task PressMouse(this Viewport viewport, MouseButton button = MouseButton.Left)
+    public static void PressMouse(this Viewport _, MouseButton button = MouseButton.Left)
     {
-        await viewport.ProcessFrame();
-
         var action = new InputEventMouseButton
         {
             ButtonIndex = button,
             Pressed = true
         };
         Input.ParseInputEvent(action);
-
-        await viewport.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
     /// <summary>
     /// Releases the given mouse button.
     /// </summary>
-    /// <param name="viewport">Viewport.</param>
+    /// <param name="_">Viewport.</param>
     /// <param name="button">Mouse button (left by default).</param>
     /// <returns>Task that completes when the input finishes.</returns>
-    public static async Task ReleaseMouse(this Viewport viewport, MouseButton button = MouseButton.Left)
+    public static void ReleaseMouse(this Viewport _, MouseButton button = MouseButton.Left)
     {
-        await viewport.ProcessFrame();
-
         var action = new InputEventMouseButton
         {
             ButtonIndex = button,
             Pressed = false
         };
         Input.ParseInputEvent(action);
-
-        await viewport.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
-    private static async Task PressMouseAt(this Viewport viewport, Vector2 position, MouseButton button = MouseButton.Left)
+    private static void PressMouseAt(this Viewport viewport, Vector2 position, MouseButton button = MouseButton.Left)
     {
-        await MoveMouseTo(viewport, position);
+        viewport.MoveMouseTo(position);
 
         var action = new InputEventMouseButton
         {
@@ -110,13 +101,12 @@ public static class MouseControlExtensions
             Position = position
         };
         Input.ParseInputEvent(action);
-
-        await viewport.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 
-    private static async Task ReleaseMouseAt(this Viewport viewport, Vector2 position, MouseButton button = MouseButton.Left)
+    private static void ReleaseMouseAt(this Viewport viewport, Vector2 position, MouseButton button = MouseButton.Left)
     {
-        await MoveMouseTo(viewport, position);
+        viewport.MoveMouseTo(position);
 
         var action = new InputEventMouseButton
         {
@@ -125,7 +115,6 @@ public static class MouseControlExtensions
             Position = position
         };
         Input.ParseInputEvent(action);
-
-        await viewport.WaitForEvents();
+        Input.FlushBufferedEvents();
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Godot Test Driver
 
 ### What is it?
+
 This library provides an API that simplifies writing integration tests for Godot projects. It provides:
+
 - A very simple and minimal framework for interacting with Godot nodes from integration tests. With it, you can effectively decouple your integration tests from the implementation details of your Godot project.
 - Working implementations for sending commands, mouse clicks and keystrokes which you will need in every integration test.
 - Drivers for many of Godot's built-in nodes which you can use as building blocks for your integration tests.
 - A fixture implementation for setting up test fixtures and destroying them properly after the test.
 
 ### What is it not?
-GodotTestDriver is not a test framework. There are already a lot of test frameworks out there (e.g GodotXUnit, WAT, GDUnit, GoDotTest, etc.) so there is no need add another one to the list. Pick one and use GodotTestDriver on top of it. GodotTestDriver is also not an assertions library. Most test frameworks come with built-in assertions, and there are also standalone assertion libraries (like Shouldly) so just use these. 
+
+GodotTestDriver is not a test framework. There are already a lot of test frameworks out there (e.g GodotXUnit, WAT, GDUnit, GoDotTest, etc.) so there is no need add another one to the list. Pick one and use GodotTestDriver on top of it. GodotTestDriver is also not an assertions library. Most test frameworks come with built-in assertions, and there are also standalone assertion libraries (like Shouldly) so just use these.
 
 ## How to use GodotTestDriver
+
 ### Installation
 
 GodotTestDriver is published on [NuGet](https://www.nuget.org/packages/GodotTestDriver). To add it use this command line command (or the NuGet facilities of your IDE):
@@ -33,7 +37,7 @@ You can check out the [OpenSCAD Graph Editor](https://github.com/derkork/opensca
 
 ### Fixtures
 
-This library provides a `Fixture` class which you can use to create and automatically dispose of Godot nodes and scenes. The fixture ensures that all tree modifications run on the main thread. 
+This library provides a `Fixture` class which you can use to create and automatically dispose of Godot nodes and scenes. The fixture ensures that all tree modifications run on the main thread.
 
 ```csharp
 using GodotTestDriver;
@@ -45,59 +49,61 @@ class MyTest {
     Fixture fixture;
     Player player;
     Arena arena;
-    
+
     // This is a setup method. The exact way of how stuff is set up
     // differs from framework to framework, but most have a setup
     // method.
     async Task Setup() {
         // Create a new Fixture instance.
         fixture = new Fixture(tree);
-        
+
         // load the arena scene. It will be automatically
         // disposed of when the fixture is disposed.
         arena = await fixture.LoadAndAddScene<Arena>("res://arena.tscn");
-        
+
         // load the player. it also will be automatically disposed.
         player = await fixture.LoadScene<Player>("res://player.tscn");
-        
+
         // add the player to the arena.
         arena.AddChild(player);
     }
-    
- 
+
+
     async Task TestBattle() {
         // load a monster. again, it will be automatically disposed.
         var monster = fixture.LoadScene<Monster>("res://monster.tscn");
-        
+
         // add the monster to the arena
         arena.AddChild(monster);
-        
+
         // create a weapon on the fly without loading a scene.
         // We call fixture.AutoFree to schedule this object for
         // deletion when the fixture is cleaned up.
         var weapon = fixture.AutoFree(new Weapon());
-        
+
         // add the weapon to the player.
         arena.AddChild(weapon);
-        
-        
+
+
         // run the actual tests.
         ....
     }
-    
+
     // You can also add custom cleanup steps to the fixture while
     // the test is running. These will be performed after the
     // test is done. This is very useful for cleaning up stuff
     // that is created during the tests.
     async Task TestSaving() {
-        ... 
+        ...
         // save the game
-        await GameDialog.SaveButton.Click();
-        
+        GameDialog.SaveButton.Click();
+
+        // await file operations here
+
         // instruct the fixture to delete our savegame in the
         // cleanup phase.
         fixture.AddCleanupStep(() => File.Delete("user://savegame.dat"));
-                
+
         // assert that the game was saved
         Assert.That(File.Exists("user://savegame.dat"));
 
@@ -105,8 +111,8 @@ class MyTest {
         // when the test is done, the fixture will run your custom
         // cleanup step (e.g. delete the save game in this case)
     }
-    
-    
+
+
     // This is a cleanup method. Like the setup method, the exact
     // way of how stuff is cleaned up differs from framework to
     // framework, but most have a cleanup method.
@@ -120,7 +126,7 @@ class MyTest {
 
 #### Loading scenes by naming convention
 
-If you have many scenes in your project, it may become cumbersome to hard-code scene paths into your tests all the time. This will also make it harder to move scenes around in your project. 
+If you have many scenes in your project, it may become cumbersome to hard-code scene paths into your tests all the time. This will also make it harder to move scenes around in your project.
 
 To solve this, you can make your scenes follow a naming convention. For example, say the root node of your `Player/Player.tscn` scene is the  `Player` node which has its script stored in `Player/Player.cs`.  You can then simply load the scene like this:
 
@@ -130,13 +136,14 @@ var player = await fixture.LoadScene<Player>();
 
 For this to work, it is important that the scene file and the script file have the same name, same spelling and casing and must reside in the same directory. The only difference must be the file extension - `.tscn` for the scene file and `.cs` for the script file.
 
-
 ## Test drivers
+
 ### Introduction
 
 Test drivers serve as an abstraction layer between your test code and your game code. They are a high level interface through which the tests can "see" the game and interact with it. With a test driver, your game tests do not need to know how the game works under the hood. This makes your tests a lot more robust to change.
 
 ### Producing nodes for the test driver to work on
+
 Test drivers work on a part of the node tree. Each test driver takes a _producer_ as argument, which is a function that is supposed to produce a node from the current tree that the driver will work on. E.g. the `ButtonDriver` takes a function that produces a button node.
 
 How exactly this node is produced depends on your game and test setup. Lets say you would use a classic test framework that has some kind of `Setup` method:
@@ -145,29 +152,30 @@ How exactly this node is produced depends on your game and test setup. Lets say 
 class MyTest {
 
     ButtonDriver buttonDriver;
-    
+
     async Task Setup() {
         buttonDriver = new ButtonDriver(() => GetTree().GetNodeOrNull<Button>("UI/MyButton"));
-        
+
         // ... more setup here
     }
 }
 ```
 
-In this example, the `ButtonDriver` would try to get the node it should work on using the `GetNodeOrNull`  function. When the driver is constructed, it will not check whether the node is actually present. This only happens when the driver is used. This way you can set up a driver without having a matching node structure in place. This is very useful as node structures can dynamically change while your tests are running (e.g. a dialog can be added to the scene or removed from it, same with monsters or players). 
+In this example, the `ButtonDriver` would try to get the node it should work on using the `GetNodeOrNull`  function. When the driver is constructed, it will not check whether the node is actually present. This only happens when the driver is used. This way you can set up a driver without having a matching node structure in place. This is very useful as node structures can dynamically change while your tests are running (e.g. a dialog can be added to the scene or removed from it, same with monsters or players).
 
 ### Using the test driver
+
 After you have created the test driver you can use it in your tests:
 
 ```csharp
 
-async Task TestButtonDisappearsWhenClicked() {
+void TestButtonDisappearsWhenClicked() {
     // when
     // will click the button in its center. This will actually
     // move the mouse set a click and trigger all the events of a
     // proper button click.
-    await buttonDriver.ClickCenter();
-    
+    buttonDriver.ClickCenter();
+
     // then
     // the button should be present but invisible.
     Assert.That(button.Visible).IsFalse();
@@ -178,6 +186,7 @@ async Task TestButtonDisappearsWhenClicked() {
 Note how your tests now interface with the driver, rather than the underlying node structure. When the `ClickCenter` method is called and the button is not actually present and visible, the method will throw an exception explaining why you cannot click the button right now. This way you will get proper error messages when you are testing your game and not just `NullReferenceException`s which greatly helps in debugging tests.
 
 ### Composition of test drivers
+
 Using a test driver by its own is nice, but it is only enough for very simple cases. Most of the time you will have complex nested node structures that make up your game entities and the UI. You can therefore compose test drivers into tree-like structures to represent these entities. Let's say you have a dialog popping up asking the player whether they want to save the game before quitting. It consists of three buttons and a label.
 
 You can write a custom driver that represents this dialog to your tests:
@@ -187,16 +196,16 @@ You can write a custom driver that represents this dialog to your tests:
 // the root of the dialog would be a panel container.
 class ConfirmationDialogDriver : ControlDriver<PanelContainer> {
 
-    // we have a label and three buttons 
+    // we have a label and three buttons
     public LabelDriver Label { get; }
     public ButtonDriver YesButton { get; }
     public ButtonDriver NoButton { get; }
     public ButtonDriver CancelButton { get; }
-    
+
     public ConfirmationDialogDriver(Func<PanelContainer> producer) : base(producer) {
         // for each of the elements we create a new driver, that
         // uses a producer fetching the respective node from below
-        // our own root node. 
+        // our own root node.
 
         // Root is a built-in property of the driver base class,
         // which will run the producer function to get the root node.
@@ -219,11 +228,11 @@ async Task Setup() {
 }
 
 
-async Task ClickingYesClosesTheDialog() {
+void ClickingYesClosesTheDialog() {
     // when
     // we click the yes button.
-    await dialogDriver.YesButton.ClickCenter();
-    
+    dialogDriver.YesButton.ClickCenter();
+
     // then
     // the dialog should be gone.
     Assert.That(dialogDriver.Visible).IsFalse();
@@ -233,7 +242,7 @@ async Task ClickingYesClosesTheDialog() {
 Note that because of the way drivers are implemented `dialogDriver.YesButton` will never throw a `NullReferenceException` even if the button is currently not present in the tree. This greatly simplifies your testing code. Also your testing code now is fully decoupled from the actual node structure. If you decide to change the node structure of the dialog, you will only need to change the `ConfirmationDialogDriver`, instead of all the tests that use it.
 
 ### Built-in drivers
- 
+
 - [BaseButtonDriver](GodotTestDriver/Drivers/BaseButtonDriver.cs) - a driver base class for button-like UI elements
 - [ButtonDriver](GodotTestDriver/Drivers/ButtonDriver.cs) - a driver for buttons
 - [Camera2DDriver](GodotTestDriver/Drivers/Camera2DDriver.cs) - a driver for 2D cameras
@@ -254,70 +263,70 @@ Note that because of the way drivers are implemented `dialogDriver.YesButton` wi
 - [TextEditDriver](GodotTestDriver/Drivers/TextEditDriver.cs) - a driver for text edits
 - [WindowDriver](GodotTestDriver/Drivers/WindowDriver.cs) - a driver for windows
 
-
 ## Input
+
+GodotTestDriver provides a number of extension methods that allow you to simulate user input. With the exception of methods that require time to elapse (e.g., `Node::HoldActionFor()`), these functions do _**not**_ wait for additional frames to elapse. This permits checking input within the same frame (required for `Input::IsActionJustPressed/Released()`). When you need additional frames to handle input, GodotTestDriver provides waiting extensions, described below.
+
 ### Simulating mouse input
-GodotTest provides a number of extension functions on `Viewport` that allow you to simulate mouse input in a viewport. 
+
+GodotTest provides a number of extension functions on `Viewport` that allow you to simulate mouse input in a viewport.
 
 ```csharp
 
 // you can move the mouse to a certain position (e.g. for simulating a hover)
-await viewport.MoveMouseTo(new Vector2(100, 100));
+viewport.MoveMouseTo(new Vector2(100, 100));
 
 // you can click at a certain position (default is left mouse button)
-await viewport.ClickMouseAt(new Vector2(100, 100));
+viewport.ClickMouseAt(new Vector2(100, 100));
 
 // you can give a ButtonList argument to click with a different mouse button
-await viewport.ClickMouseAt(new Vector2(100, 100), ButtonList.Right);
+viewport.ClickMouseAt(new Vector2(100, 100), ButtonList.Right);
 
 // you can also send single mouse presses and releases
-await viewport.PressMouse();
-await viewport.ReleaseMouse();
+viewport.PressMouse();
+viewport.ReleaseMouse();
 
 // there is also built-in support for mouse dragging
-// this will press the mouse at the first point, then move it to the 
+// this will press the mouse at the first point, then move it to the
 // second point and release it there.
-await viewport.DragMouse(new Vector2(100, 100), new Vector2(400, 400));
+viewport.DragMouse(new Vector2(100, 100), new Vector2(400, 400));
 
 // again you can give a ButtonList argument to drag with a different mouse button
-await viewport.DragMouse(new Vector2(100, 100), new Vector2(400, 400), ButtonList.Right);
+viewport.DragMouse(new Vector2(100, 100), new Vector2(400, 400), ButtonList.Right);
 ```
 
-All functions will wait until the events have been properly processed.
-
 ### Simulating keyboard input
+
 GodotTest provides a number of extension functions on `SceneTree`/`Node` that allow you to simulate keyboard input.
 
-    
 ```csharp
 
 // you can press down a key
-await node.PressKey(KeyList.A);
+node.PressKey(KeyList.A);
 // you can also specify modifiers (e.g. shift+F1)
-await node.PressKey(KeyList.F1, shift: true);
+node.PressKey(KeyList.F1, shift: true);
 // you can also specify multiple modifiers (e.g. ctrl+shift+F1)
-await node.PressKey(KeyList.F1, control: true, shift: true);
+node.PressKey(KeyList.F1, control: true, shift: true);
 
 // you can release a key
-await node.ReleaseKey(KeyList.A);
+node.ReleaseKey(KeyList.A);
 
 // you can also combine pressing and releasing a key
-await node.TypeKey(KeyList.A);
+node.TypeKey(KeyList.A);
 ```
 
-All functions will wait until the events have been properly processed.
-
 ### Simulating other actions
+
 Since version 2.1.0 you can now also simulate actions like this:
 
 ```csharp
 // start the jump action
-await node.StartAction("jump"); 
+node.StartAction("jump");
 // end the jump action
-await node.EndAction("jump");
+node.EndAction("jump");
 
 // trigger an action (start and end in one function)
-await node.TriggerAction("jump");
+node.TriggerAction("jump");
 
 // hold an action pressed for 1 second
 await node.HoldActionFor(1.0f, "jump");
@@ -360,27 +369,27 @@ public async Task TestCombat() {
     // the monster will attack the player.
     await GetTree().WithinSeconds(5, () => {
         // this assertion will be repeatedly run every frame
-        // until it either succeeds or the 5 seconds have elapsed  
+        // until it either succeeds or the 5 seconds have elapsed
         Assert.True(arena.Player.IsDead);
     });
 }
 
-// you can also check for a condition to stay true for a 
+// you can also check for a condition to stay true for a
 // certain amount of time
 public async Task TestGodMode() {
     // setup
     // give god mode to the player
-    arena.Player.EnableGodMode();    
+    arena.Player.EnableGodMode();
 
     // when
     // i open the arena gates
     arena.OpenGates();
 
     // then
-    // the player will not lose any health within the next 5 seconds 
+    // the player will not lose any health within the next 5 seconds
     await GetTree().DuringSeconds(5, () => {
         // this assertion will be repeatedly run every frame
-        // until it either fails or the 5 seconds have elapsed  
+        // until it either fails or the 5 seconds have elapsed
         Assert.Equal(arenaDriver.Player.MaxHealth, arenaDriver.Player.Health);
     });
 }
@@ -388,13 +397,12 @@ public async Task TestGodMode() {
 ```
 
 ## FAQ
-### Why is everything `async`?
 
-Integration tests in games usually trigger some operation and then need to wait for the operation to have effect. This waiting can last several frames. Using `async` / `await` makes it much easier to write such tests.
+### Why are some operations `async`?
+
+Integration tests in games may trigger some operation and then need to wait for the operation to have effect. This waiting can last several frames. Using `async` / `await` makes it much easier to write such tests, and operations that may take multiple frames to complete use `async` / `await` accordingly. Operations that complete immediately do not, but if you need to take additional frames for an operation to complete in your test, you can use the waiting extensions described above.
 
 ### What should I consider when writing my own drivers?
-- All calls should succeed if the controlled object is in a suitable state to perform the requested operation. Otherwise these calls should throw an `InvalidOperationException`. For example if you use a `ButtonDriver` and the button is not currently visible when you try to click it, the driver will throw an `InvalidOperationException`.
-- All calls that potentially modify state should always be executed in the `Process` phase. You can use the `await GetTree().ProcessFrame()` extension function that is provided by this library to wait for the process phase.
-- All calls that raise events should wait for at least two process frames before they return. This is to ensure that the event has been properly processed before the call returns. This way you don't need to litter your tests with code that waits for a few frames. You can use the `await GetTree().WaitForEvents()` extension function that is provided by this library to wait for the events to be processed.
-- Producer functions should never throw an exception. If they cannot find the node, they should just return `null`.
 
+- All calls should succeed if the controlled object is in a suitable state to perform the requested operation. Otherwise these calls should throw an `InvalidOperationException`. For example if you use a `ButtonDriver` and the button is not currently visible when you try to click it, the driver will throw an `InvalidOperationException`.
+- Producer functions should never throw an exception. If they cannot find the node, they should just return `null`.


### PR DESCRIPTION
To enable users to test that operations happen at the time they're requested, rather than at an indeterminate point in the next couple frames, this PR removes `async`/`await` from as many driver functions as practicable. This is especially useful for operations that require same-frame checks, such as `Input::IsActionJustPressed/Released()`. This change also speeds up many tests, since there is less waiting on the engine to process frames. Users can continue to support multi-frame tests by using the waiting extension methods themselves.

Additionally, this PR adds support/workaround for the separation of input action *events* and input action *state* in Godot 4.2, so that `StartAction()` and `EndAction()` extension methods continue to set global input state (e.g., `Input::IsActionPressed()`).

## Exceptions to synchronization
* `ActionsControlExtensions::HoldActionFor()` - requires an `await` to hold the action
* `KeyboardControlExtensions::HoldKeyFor()` - requires an `await` to hold the key press
* `Camera2DDriver::MoveIntoView()` and `Camera2DDriver::WaitUntilSteady()` - because `Camera2D` incorporates its own motion-easing model, it's not straightforward to eliminate asynchrony in waiting for its motion to finish. I've added a method that starts moving the camera and returns immediately, but users who want to have the camera at its new position afterwards will need to use `WaitUntilSteady()` themselves.
* `Fixture::AddToRoot()` and dependent methods - requires waiting a frame for a new `Node`'s `_Ready()` method to be called
* `Fixture` cleanup actions - may require asynchronous operations (e.g., deleting a file)

## Other notes
I've made `TabContainerDriver` methods for selecting a tab synchronous, even though Godot takes an extra frame to update content visibility. In lieu of waiting for contents to become visible, I've added a note to the documentation for tab-selection methods about this, and updated the content-visibility test to manually wait a frame after selecting a tab and before checking visibility.

## BREAKING CHANGES
Most driver methods are no longer `async`, are `void` instead of returning `Task` (or return `T` instead of `Task<T>`), and do not have a frame delay.